### PR TITLE
Use `impl Into<String>` whenever possible

### DIFF
--- a/onedrive-api-test/tests/real_test/main.rs
+++ b/onedrive-api-test/tests/real_test/main.rs
@@ -33,7 +33,7 @@ async fn test_get_drive() {
     let drive_id = drive1.id.as_ref().expect("drive1 has no id");
 
     // #2
-    let drive2 = OneDrive::new(onedrive.access_token().to_owned(), drive_id.clone())
+    let drive2 = OneDrive::new(onedrive.access_token(), drive_id.clone())
         .get_drive_with_option(ObjectOption::new().select(&[DriveField::id, DriveField::owner]))
         .await
         .expect("Cannot get drive #2");
@@ -44,7 +44,7 @@ async fn test_get_drive() {
     // #3
     assert_eq!(
         OneDrive::new(
-            onedrive.access_token().to_owned(),
+            onedrive.access_token(),
             DriveId(format!("{}_inva_lid", drive_id.as_str())),
         )
         .get_drive()
@@ -620,9 +620,9 @@ async fn test_track_changes() {
 #[tokio::test]
 async fn test_auth_error() {
     let auth = Auth::new(
-        "11111111-2222-3333-4444-555555555555".to_owned(),
+        "11111111-2222-3333-4444-555555555555",
         Permission::new_read().offline_access(true),
-        "https://login.microsoftonline.com/common/oauth2/nativeclient".to_owned(),
+        "https://login.microsoftonline.com/common/oauth2/nativeclient",
     );
 
     {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -76,7 +76,7 @@ pub struct Auth {
 impl Auth {
     /// Create an new instance for OAuth2 to Microsoft Graph
     /// with specified client identifier and permission.
-    pub fn new(client_id: String, permission: Permission, redirect_uri: String) -> Self {
+    pub fn new(client_id: impl Into<String>, permission: Permission, redirect_uri: impl Into<String>) -> Self {
         Self::new_with_client(Client::new(), client_id, permission, redirect_uri)
     }
 
@@ -85,15 +85,15 @@ impl Auth {
     /// [auth_new]: #method.new
     pub fn new_with_client(
         client: Client,
-        client_id: String,
+        client_id: impl Into<String>,
         permission: Permission,
-        redirect_uri: String,
+        redirect_uri: impl Into<String>,
     ) -> Self {
         Self {
             client,
-            client_id,
+            client_id: client_id.into(),
             permission,
-            redirect_uri,
+            redirect_uri: redirect_uri.into(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! # async fn run() -> onedrive_api::Result<()> {
 //! let client = Client::new();
 //! let drive = OneDrive::new(
-//!     "<...TOKEN...>".to_owned(), // Login token to Microsoft Graph.
+//!     "<...TOKEN...>", // Login token to Microsoft Graph.
 //!     DriveLocation::me(),
 //! );
 //!

--- a/src/onedrive.rs
+++ b/src/onedrive.rs
@@ -45,7 +45,7 @@ pub struct OneDrive {
 
 impl OneDrive {
     /// Create a new OneDrive instance with access token given to perform operations in a Drive.
-    pub fn new(access_token: String, drive: impl Into<DriveLocation>) -> Self {
+    pub fn new(access_token: impl Into<String>, drive: impl Into<DriveLocation>) -> Self {
         let client = Client::builder()
             .redirect(reqwest::redirect::Policy::none())
             .gzip(true)
@@ -65,12 +65,12 @@ impl OneDrive {
     /// [get_url]: #method.get_item_download_url_with_option
     pub fn new_with_client(
         client: Client,
-        access_token: String,
+        access_token: impl Into<String>,
         drive: impl Into<DriveLocation>,
     ) -> Self {
         OneDrive {
             client,
-            token: access_token,
+            token: access_token.into(),
             drive: drive.into(),
         }
     }
@@ -891,8 +891,8 @@ impl CopyProgressMonitor {
     /// `monitor_url` should be got from [`CopyProgressMonitor::monitor_url`][monitor_url]
     ///
     /// [monitor_url]: #method.monitor_url
-    pub fn from_monitor_url(monitor_url: String) -> Self {
-        Self { monitor_url }
+    pub fn from_monitor_url(monitor_url: impl Into<String>) -> Self {
+        Self { monitor_url: monitor_url.into() }
     }
 
     /// Get the monitor url.
@@ -940,10 +940,10 @@ impl DriveItemFetcher {
         }
     }
 
-    fn resume_from(next_url: String) -> Self {
+    fn resume_from(next_url: impl Into<String>) -> Self {
         Self::new(DriveItemCollectionResponse {
             value: None,
-            next_url: Some(next_url),
+            next_url: Some(next_url.into()),
             delta_url: None,
         })
     }
@@ -1015,7 +1015,7 @@ impl ListChildrenFetcher {
     /// [`ListChildrenFetcher::next_url`][next_url].
     ///
     /// [next_url]: #method.next_url
-    pub fn resume_from(next_url: String) -> Self {
+    pub fn resume_from(next_url: impl Into<String>) -> Self {
         Self {
             fetcher: DriveItemFetcher::resume_from(next_url),
         }
@@ -1082,7 +1082,7 @@ impl TrackChangeFetcher {
     /// The url should be from [`TrackChangeFetcher::next_url`][next_url].
     ///
     /// [next_url]: #method.next_url
-    pub fn resume_from(next_url: String) -> Self {
+    pub fn resume_from(next_url: impl Into<String>) -> Self {
         Self {
             fetcher: DriveItemFetcher::resume_from(next_url),
         }
@@ -1190,8 +1190,8 @@ impl UploadSession {
     pub const MAX_PART_SIZE: usize = 60 << 20; // 60 MiB
 
     /// Construct back the upload session from upload URL.
-    pub fn from_upload_url(upload_url: String) -> Self {
-        Self { upload_url }
+    pub fn from_upload_url(upload_url: impl Into<String>) -> Self {
+        Self { upload_url: upload_url.into() }
     }
 
     /// Query the metadata of the upload to find out which byte ranges

--- a/src/util.rs
+++ b/src/util.rs
@@ -43,9 +43,9 @@ impl DriveLocation {
     ///
     /// # See also
     /// [Microsoft Docs](https://docs.microsoft.com/en-us/graph/api/drive-get?view=graph-rest-1.0#get-a-users-onedrive)
-    pub fn from_user(id_or_principal_name: String) -> Self {
+    pub fn from_user(id_or_principal_name: impl Into<String>) -> Self {
         Self {
-            inner: DriveLocationEnum::User(id_or_principal_name),
+            inner: DriveLocationEnum::User(id_or_principal_name.into()),
         }
     }
 
@@ -53,9 +53,9 @@ impl DriveLocation {
     ///
     /// # See also
     /// [Microsoft Docs](https://docs.microsoft.com/en-us/graph/api/drive-get?view=graph-rest-1.0#get-the-document-library-associated-with-a-group)
-    pub fn from_group(group_id: String) -> Self {
+    pub fn from_group(group_id: impl Into<String>) -> Self {
         Self {
-            inner: DriveLocationEnum::Group(group_id),
+            inner: DriveLocationEnum::Group(group_id.into()),
         }
     }
 
@@ -63,9 +63,9 @@ impl DriveLocation {
     ///
     /// # See also
     /// [Microsoft Docs](https://docs.microsoft.com/en-us/graph/api/drive-get?view=graph-rest-1.0#get-the-document-library-for-a-site)
-    pub fn from_site(site_id: String) -> Self {
+    pub fn from_site(site_id: impl Into<String>) -> Self {
         Self {
-            inner: DriveLocationEnum::Site(site_id),
+            inner: DriveLocationEnum::Site(site_id.into()),
         }
     }
 


### PR DESCRIPTION
With `impl Into<String>`, we can accept many other kinds of values, such as `&str`, `Cow<str>`. `String` is still accepted without copying since we always have `impl Into<T> for T`, and other reference types will be automatically copied.

This reduces the needs for `.to_owned()` everywhere.