### PR TITLE
feat: rustls support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,17 @@ readme = "README.md"
 documentation = "https://docs.rs/onedrive-api"
 
 [features]
-default = ["reqwest/default"]
+default = []
 beta = []
 
 [dependencies]
 # Compat with `reqwest`
 bytes = "1.0.1"
-reqwest = { version = "0.11.0", default-features = false, features = ["json", "gzip"] }
+reqwest = { version = "0.11.0", default-features = false, features = [
+    "json",
+    "gzip",
+    "rustls-tls",
+] }
 serde = { version = "1.0.102", features = ["derive"] }
 serde_json = "1.0.41"
 strum = { version = "0.24", features = ["derive"] }


### PR DESCRIPTION
I'm using this in a project, and recently I've decided to move completely off of using openssl.

To support that, this API needs to support `rustls`. This patch passed `cargo test`, however I don't have the ability to use the `onedrive-api-test` sub-crate to test it right now.

Theoretically, this should be a no-op as far as usage goes.