### PR TITLE
Add support to create a DriveItem with many attributes in a single request

### DIFF
--- a/src/resource.rs
+++ b/src/resource.rs
@@ -210,6 +210,7 @@ define_resource_object! {
         // Drive item
 
         pub audio: Option<JsonValue>,
+        pub bundle: Option<JsonValue>,
         pub content: Option<JsonValue>,
         pub c_tag: Option<Tag>,
         pub deleted: Option<JsonValue>,


### PR DESCRIPTION
## Introduction
This lib does not have the ability to create a `DriveItem` with a description or any other fields but name, at least I couldn't find a way to do this in a single request.

Probably it is possible to add a description to a `DriveItem` with `update_item`/`update_item_with_option`, but it is inefficient to perform two requests when a single one can be done.

## Changes
- Introduce a few good-to-have implementations for `ConflictBehavior` enum
- Update the DriveItem struct macro to allow the conflict behavior to be set
- Refactor the original `create_folder_with_options` to use the new implementation

## Impact and benefits
- Users can now create DriveItems with additional fields, such as description, in a single request, improving usability and efficiency.
- The changes do not introduce breaking changes and are backward-compatible with existing usage of the library.
- Any supported field can be added to the request, as long as it is compatible with the [Microsoft documentation](https://learn.microsoft.com/en-us/graph/api/resources/driveitem?view=graph-rest-1.0#properties).

## Tests
Tests are already covered  as `create_document_with_options` is using the new implementation.

## Requests for review
Feedback and review from other contributors and maintainers are highly appreciated, especially regarding the implementation details, and documentation clarity.