### PR TITLE
Add serialization support for TokenResponse struct

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -5,7 +5,7 @@ use crate::{
     util::handle_oauth2_error_response,
 };
 use reqwest::Client;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 /// A list of the Microsoft Graph permissions that you want the user to consent to.
@@ -348,7 +348,7 @@ impl ClientCredential {
 ///
 /// # See also
 /// [Microsoft Docs](https://docs.microsoft.com/en-us/graph/auth-v2-user?view=graph-rest-1.0#token-response)
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct TokenResponse {
     /// Indicates the token type value. The only type that Azure AD supports is Bearer.

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -354,7 +354,8 @@ pub struct TokenResponse {
     /// Indicates the token type value. The only type that Azure AD supports is Bearer.
     pub token_type: String,
     /// A list of the Microsoft Graph permissions that the access_token is valid for.
-    #[serde(deserialize_with = "space_separated_strings")]
+    #[serde(deserialize_with = "deserialize_space_separated_strings")]
+    #[serde(serialize_with = "serialize_space_separated_strings")]
     pub scope: Vec<String>,
     /// How long the access token is valid (in seconds).
     #[serde(rename = "expires_in")]
@@ -385,7 +386,9 @@ impl fmt::Debug for TokenResponse {
     }
 }
 
-fn space_separated_strings<'de, D>(deserializer: D) -> std::result::Result<Vec<String>, D::Error>
+fn deserialize_space_separated_strings<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Vec<String>, D::Error>
 where
     D: serde::de::Deserializer<'de>,
 {
@@ -407,6 +410,17 @@ where
     }
 
     deserializer.deserialize_str(Visitor)
+}
+
+fn serialize_space_separated_strings<S>(
+    value: &[String],
+    serializer: S,
+) -> std::result::Result<S::Ok, S::Error>
+where
+    S: serde::ser::Serializer,
+{
+    let space_separated = value.join(" ");
+    serializer.serialize_str(&space_separated)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
It would be nice to have serialization support for the `TokenResponse` struct, to save it to a file for persistence between app restarts without having to manually log in again.