### PR TITLE
wasm support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,17 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: cargo fmt
         run: cargo fmt --all -- --check
+  
+  wasm:
+    name: wasm32 build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+      - name: wasm32 build
+        run: cargo build --target=wasm32-unknown-unknown
 
   clippy:
     name: Clippy

--- a/src/onedrive.rs
+++ b/src/onedrive.rs
@@ -62,11 +62,15 @@ impl OneDrive {
     /// # Panics
     /// It panics if the underlying `reqwest::Client` cannot be created.
     pub fn new(access_token: impl Into<String>, drive: impl Into<DriveLocation>) -> Self {
+        #[cfg(not(target_arch = "wasm32"))]
         let client = Client::builder()
             .redirect(reqwest::redirect::Policy::none())
             .gzip(true)
             .build()
             .unwrap();
+        #[cfg(target_arch = "wasm32")]
+        let client = Client::builder().build().unwrap();
+
         Self::new_with_client(client, access_token, drive.into())
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -268,34 +268,27 @@ impl RequestBuilderExt for RequestBuilder {
     }
 }
 
-type BoxFuture<T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'static>>;
-
-// TODO: Avoid boxing?
 pub(crate) trait ResponseExt: Sized {
-    fn parse<T: de::DeserializeOwned>(self) -> BoxFuture<Result<T>>;
-    fn parse_optional<T: de::DeserializeOwned>(self) -> BoxFuture<Result<Option<T>>>;
-    fn parse_no_content(self) -> BoxFuture<Result<()>>;
+    async fn parse<T: de::DeserializeOwned>(self) -> Result<T>;
+    async fn parse_optional<T: de::DeserializeOwned>(self) -> Result<Option<T>>;
+    async fn parse_no_content(self) -> Result<()>;
 }
 
 impl ResponseExt for Response {
-    fn parse<T: de::DeserializeOwned>(self) -> BoxFuture<Result<T>> {
-        Box::pin(async move { Ok(handle_error_response(self).await?.json().await?) })
+    async fn parse<T: de::DeserializeOwned>(self) -> Result<T> {
+        Ok(handle_error_response(self).await?.json().await?)
     }
 
-    fn parse_optional<T: de::DeserializeOwned>(self) -> BoxFuture<Result<Option<T>>> {
-        Box::pin(async move {
-            match self.status() {
-                StatusCode::NOT_MODIFIED | StatusCode::ACCEPTED => Ok(None),
-                _ => Ok(Some(handle_error_response(self).await?.json().await?)),
-            }
-        })
+    async fn parse_optional<T: de::DeserializeOwned>(self) -> Result<Option<T>> {
+        match self.status() {
+            StatusCode::NOT_MODIFIED | StatusCode::ACCEPTED => Ok(None),
+            _ => Ok(Some(handle_error_response(self).await?.json().await?)),
+        }
     }
 
-    fn parse_no_content(self) -> BoxFuture<Result<()>> {
-        Box::pin(async move {
-            handle_error_response(self).await?;
-            Ok(())
-        })
+    async fn parse_no_content(self) -> Result<()> {
+        handle_error_response(self).await?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This changes `ResponseExt` and `OneDrive::new()` to support wasm32. Also avoids boxing in `ResponseExt`