### PR TITLE
Adds getting a drive user info to drive

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -17,6 +17,7 @@ pub struct Permission {
     write: bool,
     access_shared: bool,
     offline_access: bool,
+    read_user:bool,
 }
 
 impl Permission {
@@ -42,6 +43,13 @@ impl Permission {
         self
     }
 
+    /// Set the read user permission.
+    #[must_use]
+    pub fn read_user(mut self, read_user: bool) -> Self {
+        self.read_user = read_user;
+        self
+    }
+
     /// Set whether allows offline access.
     ///
     /// This permission is required to get a [`TokenResponse::refresh_token`] for long time access.
@@ -58,10 +66,12 @@ impl Permission {
     #[rustfmt::skip]
     fn to_scope_string(self) -> String {
         format!(
-            "{}{}{}",
+            "{}{}{}{}",
             if self.write { "files.readwrite" } else { "files.read" },
             if self.access_shared { ".all" } else { "" },
             if self.offline_access { " offline_access" } else { "" },
+            if self.offline_access { " user.read" } else { "" },
+
         )
     }
 }

--- a/src/onedrive.rs
+++ b/src/onedrive.rs
@@ -2,12 +2,12 @@
 use crate::{
     error::{Error, Result},
     option::{CollectionOption, DriveItemPutOption, ObjectOption},
-    resource::{Drive, DriveField, DriveItem, DriveItemField, TimestampString},
+    resource::{Drive, DriveField, DriveItem, DriveItemField, TimestampString, User},
     util::{
         handle_error_response, ApiPathComponent, DriveLocation, FileName, ItemLocation,
         RequestBuilderExt as _, ResponseExt as _,
     },
-    {ConflictBehavior, ExpectRange},
+    ConflictBehavior, ExpectRange,
 };
 use bytes::Bytes;
 use reqwest::{header, Client};
@@ -101,6 +101,22 @@ impl OneDrive {
     #[must_use]
     pub fn access_token(&self) -> &str {
         &self.token
+    }
+
+    /// Get current `UserInfo`.
+    ///
+    /// 
+    ///
+    /// # See also
+    /// [Microsoft Docs](https://learn.microsoft.com/en-us/graph/api/user-get?view=graph-rest-1.0)
+    pub async fn get_user_info(&self) -> Result<User> {
+        self.client
+            .get(api_url!["me"])
+            .bearer_auth(&self.token)
+            .send()
+            .await?
+            .parse()
+            .await
     }
 
     /// Get current `Drive`.

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -168,6 +168,27 @@ macro_rules! define_resource_object {
 }
 
 define_resource_object! {
+
+    /// User resource type
+    ///
+    /// The User resource type represents a Microsoft Entra user account. 
+    ///
+    /// # See also
+    /// [Microsoft Docs](https://learn.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0)
+    pub struct User #UserItemField {
+        pub business_phones: Option<Vec<String>>,
+        pub display_name: Option<String>,
+        pub given_name: Option<String>,
+        pub job_title: Option<String>,
+        pub mail: Option<String>,
+        pub mobile_phone: Option<String>,
+        pub office_location: Option<String>,
+        pub preferred_language: Option<String>,
+        pub surname: Option<String>,
+        pub user_principal_name: Option<String>,
+        pub id: Option<String>,
+     }
+ 
     /// Drive resource type
     ///
     /// The drive resource is the top level object representing a user's OneDrive


### PR DESCRIPTION
This isn't exactly one-drive but it is very one-drive related.
This api allows us to grab the user's preliminary info like name/email and we can tie this in to show things like ownership of the personal drive. 
